### PR TITLE
fix some show subcommands need more time in python 3.11

### DIFF
--- a/fwutil/__init__.py
+++ b/fwutil/__init__.py
@@ -1,5 +1,0 @@
-try:
-    from sonic_platform.platform import Platform
-    from . import main
-except ImportError as e:
-    raise ImportError("Required module not found: {}".format(str(e)))

--- a/fwutil/lib.py
+++ b/fwutil/lib.py
@@ -21,7 +21,7 @@ try:
     from sonic_py_common import device_info
     from tabulate import tabulate
 
-    from . import Platform
+    from sonic_platform.platform import Platform
     from .log import LogHelper
     from sonic_py_common.general import check_output_pipe
 except ImportError as e:

--- a/fwutil/main.py
+++ b/fwutil/main.py
@@ -9,7 +9,6 @@ try:
     import os
     import click
 
-    from .lib import PlatformDataProvider, ComponentStatusProvider, ComponentUpdateProvider
     from .lib import URL, SquashFs, FWPackage
     from .log import LogHelper
 except ImportError as e:
@@ -37,7 +36,6 @@ ROOT_UID = 0
 
 # ========================= Variables ==========================================
 
-pdp = PlatformDataProvider()
 log_helper = LogHelper()
 
 # ========================= Helper functions ===================================
@@ -98,6 +96,8 @@ def all_update(ctx):
 
 
 def chassis_handler(ctx):
+    from .lib import PlatformDataProvider
+    pdp = PlatformDataProvider()
     ctx.obj[CHASSIS_NAME_CTX_KEY] = pdp.chassis.get_name()
     ctx.obj[COMPONENT_PATH_CTX_KEY].append(pdp.chassis.get_name())
 
@@ -119,12 +119,16 @@ def chassis_update(ctx):
 
 
 def module_handler(ctx, module_name):
+    from .lib import PlatformDataProvider
+    pdp = PlatformDataProvider()
     ctx.obj[MODULE_NAME_CTX_KEY] = module_name
     ctx.obj[COMPONENT_PATH_CTX_KEY].append(pdp.chassis.get_name())
     ctx.obj[COMPONENT_PATH_CTX_KEY].append(module_name)
 
 
 def validate_module(ctx, param, value):
+    from .lib import PlatformDataProvider
+    pdp = PlatformDataProvider()
     if value == HELP:
         cli_show_help(ctx)
 
@@ -160,6 +164,7 @@ def component_handler(ctx, component_name):
 
 
 def validate_component(ctx, param, value):
+    pdp = PlatformDataProvider()
     if value == HELP:
         cli_show_help(ctx)
 
@@ -292,10 +297,13 @@ def fw_install(ctx, yes, fw_path):
 @click.pass_context
 def fw_update(ctx, yes, force, image):
     """Update firmware from SONiC image"""
+    from .lib import ComponentUpdateProvider
     if CHASSIS_NAME_CTX_KEY in ctx.obj:
         chassis_name = ctx.obj[CHASSIS_NAME_CTX_KEY]
         module_name = None
     elif MODULE_NAME_CTX_KEY in ctx.obj:
+        from .lib import PlatformDataProvider
+        pdp = PlatformDataProvider()
         chassis_name = pdp.chassis.get_name()
         module_name = ctx.obj[MODULE_NAME_CTX_KEY]
 
@@ -350,6 +358,7 @@ def fw_update(ctx, yes, force, image):
 @click.pass_context
 def fw_auto_update(ctx, boot, image=None, fw_image=None):
     """Update firmware from SONiC image"""
+    from .lib import ComponentUpdateProvider
     squashfs = None
     fwpackage = None
     cup = None
@@ -410,6 +419,7 @@ def show():
 @click.pass_context
 def updates(ctx, image=None, fw_image=None):
     """Show available updates"""
+    from .lib import ComponentUpdateProvider
     try:
         squashfs = None
         fwpackage = None
@@ -455,6 +465,7 @@ def updates(ctx, image=None, fw_image=None):
 def status(ctx):
     """Show platform components status"""
     try:
+        from .lib import ComponentStatusProvider
         csp = ComponentStatusProvider()
         click.echo(csp.get_status())
     except Exception as e:
@@ -467,6 +478,7 @@ def status(ctx):
 def update_all_status(ctx):
     """Show platform components update all status"""
     try:
+        from .lib import ComponentStatusProvider
         csp = ComponentStatusProvider()
         click.echo(csp.get_au_status())
     except Exception as e:

--- a/scripts/decode-syseeprom
+++ b/scripts/decode-syseeprom
@@ -10,7 +10,7 @@
 #
 # This is the main script that handles eeprom encoding and decoding
 #
-import optparse
+import argparse
 import os
 import re
 import sys
@@ -210,14 +210,14 @@ def print_model(use_db=False):
 # sets global variable "optcfg"
 #
 def get_cmdline_opts():
-    optcfg = optparse.OptionParser(usage='usage: {} [-s][-m]'.format(sys.argv[0]))
-    optcfg.add_option('-d', dest='db', action='store_true',
+    optcfg = argparse.ArgumentParser(usage='usage: {} [-s][-m]'.format(sys.argv[0]))
+    optcfg.add_argument('-d', dest='db', action='store_true',
                       default=False, help='print eeprom from database')
-    optcfg.add_option('-s', dest='serial', action='store_true',
+    optcfg.add_argument('-s', dest='serial', action='store_true',
                       default=False, help='print device serial number/service tag')
-    optcfg.add_option('-p', dest='modelstr', action='store_true', default=False,
+    optcfg.add_argument('-p', dest='modelstr', action='store_true', default=False,
                       help='print the device product name')
-    optcfg.add_option('-m', dest='mgmtmac', action='store_true', default=False,
+    optcfg.add_argument('-m', dest='mgmtmac', action='store_true', default=False,
                       help='print the base mac address for management interfaces')
     return optcfg.parse_args()
 
@@ -228,7 +228,7 @@ def main():
         print('Root privileges are required for this operation')
         return 1
 
-    (opts, args) = get_cmdline_opts()
+    opts = get_cmdline_opts()
 
     # Get platform name
     platform = device_info.get_platform()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

